### PR TITLE
Suppression de la sous-section 4.3.8 : Commissions

### DIFF
--- a/Statuts.md
+++ b/Statuts.md
@@ -203,10 +203,6 @@ L’objectif du/de la responsable du pôle communication est de gérer la commun
 
 Les responsabilités, objectifs et compétences requises pour le poste de responsable communication sont indiqués dans le règlement intérieur.
 
-#### Sous-Section 4.3.8 : Commissions
-
-Le Bureau peut créer des commissions par axes. Elles sont dotées d’un/une président(e) et d’un/une vice-président(e) nommés par le Bureau auxquels le/la président(e) et le/la vice-président(e) de l’association pourront déléguer partiellement ou totalement leurs pouvoirs.
-
 ## Article 5 : Assemblée Générale (AG)
 
 ### Section 5.1 : AG Ordinaire


### PR DESCRIPTION
Ca n'a pas grand chose à faire dans nos statuts.
Personne n'a jamais créer de commissions et la nécessité de mentionner dans nos registres que nous pouvons créer des groupes de travail me paraît un peu justifiée.